### PR TITLE
add ability to pass on oauth options to authProvider

### DIFF
--- a/lib/src/authProvider.ts
+++ b/lib/src/authProvider.ts
@@ -3,16 +3,17 @@ import type PocketBase from "pocketbase";
 import { isClientResponseError, toHttpError } from "./utils";
 import { OAuth2AuthConfig } from "pocketbase";
 
-export interface LoginWithProvider {
-  providerName: string;
+export interface LoginWithProvider extends OAuth2AuthConfig {
+  providerName: string; // providerName prop is used by several AuthPage implementations
 }
+
 export interface LoginWithPassword {
   email: string;
   password: string;
   remember: boolean;
 }
 
-export type LoginOptions = OAuth2AuthConfig | LoginWithPassword;
+export type LoginOptions = LoginWithProvider | LoginWithPassword;
 
 export interface AuthOptions {
   collection?: string;
@@ -126,10 +127,9 @@ export const authProvider = (
     login: async (loginOptions: LoginOptions) => {
       try {
         if (isLoginWithProvider(loginOptions)) {
-          const { provider, ...oauthOptions } = loginOptions as OAuth2AuthConfig
           await pb
             .collection(options.collection)
-            .authWithOAuth2({ provider: loginOptions.providerName, ...oauthOptions });
+            .authWithOAuth2({ ...loginOptions, provider: loginOptions.providerName });
           if (pb.authStore.isValid) {
             return {
               success: true,

--- a/lib/src/authProvider.ts
+++ b/lib/src/authProvider.ts
@@ -1,6 +1,7 @@
 import { AuthBindings, UpdatePasswordFormTypes } from "@refinedev/core";
 import type PocketBase from "pocketbase";
 import { isClientResponseError, toHttpError } from "./utils";
+import { OAuth2AuthConfig } from "pocketbase";
 
 export interface LoginWithProvider {
   providerName: string;
@@ -11,7 +12,7 @@ export interface LoginWithPassword {
   remember: boolean;
 }
 
-export type LoginOptions = LoginWithProvider | LoginWithPassword;
+export type LoginOptions = OAuth2AuthConfig | LoginWithPassword;
 
 export interface AuthOptions {
   collection?: string;
@@ -125,9 +126,10 @@ export const authProvider = (
     login: async (loginOptions: LoginOptions) => {
       try {
         if (isLoginWithProvider(loginOptions)) {
+          const { provider, ...oauthOptions } = loginOptions as OAuth2AuthConfig
           await pb
             .collection(options.collection)
-            .authWithOAuth2({ provider: loginOptions.providerName });
+            .authWithOAuth2({ provider: loginOptions.providerName, ...oauthOptions });
           if (pb.authStore.isValid) {
             return {
               success: true,


### PR DESCRIPTION
This enables one to pass extra options to oauth, as described on [this](https://github.com/pocketbase/pocketbase/discussions/5177) thread.

In refine, this can be achieved by passing props to `AuthPage` component.

For .e.g.
```js
<AuthPage
  ......
  mutationVariables={{ scopes: ["user-read-private", "user-top-read"] }}
  providers={[
    {
      name: "spotify",
      label: "Login with Spotify",
      icon: <SpotifyIcon />
    }
  ]}
/>
```

which is then evaluated as 
```js
await pb.collection("example").authWithOAuth2({
    provider: "spotify",
    scopes: ["user-read-private", "user-top-read"]
})
```
at `authProvider` level.

